### PR TITLE
Fix unreachable warning in fetch file ids

### DIFF
--- a/src/picframe/create_new_slideshow.py
+++ b/src/picframe/create_new_slideshow.py
@@ -53,8 +53,8 @@ class NewSlideshow:
                     self.__logger.warning("No files available for slideshow")
                     return None
                 if len(data) < self.min_set_size:
-                    return None
                     self.__logger.warning("Not enough files available to shuffle")
+                    return None
                 return data
 
         except Exception as e:


### PR DESCRIPTION
Log "Not enough files available to shuffle" warning before returning None to ensure it is always emitted.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c566d27-c7bc-442b-9c00-bc2bece563c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c566d27-c7bc-442b-9c00-bc2bece563c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

